### PR TITLE
catch AttributeError when self.view.file_name() is None

### DIFF
--- a/open_url.py
+++ b/open_url.py
@@ -23,7 +23,7 @@ class OpenUrlCommand(sublime_plugin.TextCommand):
 		# find the relative path to the current file 'google.com'
 		try:
 			relative_path = os.path.normpath(os.path.join(os.path.dirname(self.view.file_name()), url))
-		except TypeError:
+		except (TypeError, AttributeError):
 			relative_path = None
 
 		# debug info


### PR DESCRIPTION
Catch error when attempting to open url in a "new" unsaved file.
