### PR TITLE
expand variables in the path

### DIFF
--- a/open_url.py
+++ b/open_url.py
@@ -14,6 +14,9 @@ class OpenUrlCommand(sublime_plugin.TextCommand):
 		if url is None:
 			url = self.selection()
 
+		# expand variables in the path
+		url = os.path.expandvars(url)
+
 		# strip quotes if quoted
 		if (url.startswith("\"") & url.endswith("\"")) | (url.startswith("\'") & url.endswith("\'")):
 			url = url[1:-1]


### PR DESCRIPTION
Expanding vars in the path could be a great feature (for me at least).

For example, I can have a link looking like "$DROPBOX/todo.txt" with a customized environment variable DROPBOX in different machines.