### PR TITLE
Add ability to remove trailing characters in URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ To customize these, hit <kbd>shift+cmd+p</kbd> to open the Command Palette, and 
 - __delimeters__
   + characters at which auto-expansion of selected path stops, e.g. ` \t\n\r\"',*<>[]()`
   + the default settings are Markdown friendly
+- __trailing_delimiters__
+  + if any of these characters are seen at the end of the URL, they are recursively removed, default `;.:`
 - __web_browser__
   + the browser that Open URL uses to open new tabs; must be a string [from this list](https://docs.python.org/3.3/library/webbrowser.html)
   + if you use an empty string, the "default browser" will be used

--- a/open_url.py
+++ b/open_url.py
@@ -20,9 +20,37 @@ def prepend_scheme(s):
 	return s
 
 
+def remove_trailing_delimiter(url, trailing_delimiters):
+	"""Removes trailing delimiters.
+
+	Args:
+		url: A url that could potentially have some trailing characters that
+			need to be removed.
+		trailing_delimiters: A string of characters that should not be seen at
+			the end of a URL.
+
+	Returns:
+		The input url with the trailing delimiting characters removed; if any
+		are found.
+	"""
+	# If no trailing_delimiters are present, then we can simply return the url.
+	if not trailing_delimiters:
+		return url
+	# Go over characters from he end of the URL until we don't find a trailing
+	# delimiter character.
+	loop = True
+	while loop and url:
+		if url[-1] in trailing_delimiters:
+			url = url[:-1]
+		else:
+			loop = False
+	return url
+
+
 class OpenUrlCommand(sublime_plugin.TextCommand):
 	def run(self, edit=None, url=None, show_menu=True):
 		self.config = sublime.load_settings('open_url.sublime-settings')
+		trailing_delimiters = self.config.get('trailing_delimiters')
 
 		# Sublime Text has its own open_url command used for things like Help > Documentation
 		# so if a url is passed, open it instead of getting text from the view
@@ -39,7 +67,9 @@ class OpenUrlCommand(sublime_plugin.TextCommand):
 			return
 
 		if is_url(url):
-			self.open_tab(prepend_scheme(url))
+			url = prepend_scheme(url)
+			url = remove_trailing_delimiter(url, trailing_delimiters)
+			self.open_tab(url)
 		else:
 			self.modify_or_search_action(url)
 

--- a/open_url.sublime-settings
+++ b/open_url.sublime-settings
@@ -4,6 +4,10 @@
   // delimiters for expanding selection, these are markdown friendly
   "delimiters": " \t\n\r\"'`,*<>[](){}",
 
+  // If these delimiting characters are seen at the end of the URL, they are removed. The trailing delimiters are removed iteratively,
+  // so sublimetext.com.; will become sublimetext.com .
+  "trailing_delimiters": ";.:",
+
   // the browser that Open URL uses to open new tabs
   // it can be an empty string, or a string [from this list](https://docs.python.org/3.3/library/webbrowser.html)
   "web_browser": "",


### PR DESCRIPTION
Sometimes, we might see a URL at the end of a sentence, and the
period is seen directly after the URL, which creates problems when
opening URLs; for example `https://www.sublimetext.com/blog.` cannot be
opened.

The changes here allow removing trailing delimiters from a configurable list of
delimiters. Besides periods, the default configuration will also remove colons
and semicolons.

This PR was tested on the following URLs -

    https://www.sublimetext.com/blog
    https://www.sublimetext.com/blog.
    https://www.sublimetext.com/blog.;
    https://www.sublimetext.com/blog....